### PR TITLE
Skip s3 fetch if tar exists locally

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -65,7 +65,12 @@ function restore() {
     cache_restore_skip "s3://${BUCKET}/${TAR_FILE}"
   else
     cache_hit "s3://${BUCKET}/${TAR_FILE}"
-    aws s3 cp $BK_AWS_ARGS "s3://${BUCKET}/${TAR_FILE}" .
+    if test -f "${TAR_FILE}"; then
+      cache_hit "tar://${TAR_FILE}"
+      echo "Using local tar cache instead of s3 cache"
+    else 
+      aws s3 cp $BK_AWS_ARGS "s3://${BUCKET}/${TAR_FILE}" .
+    fi
     tar ${BK_TAR_EXTRACT_ARGS} "${TAR_FILE}" -C .
   fi
 }


### PR DESCRIPTION
https://fastaf.atlassian.net/browse/RAP-893

Planning this as a MINOR semver bump.

This adds logic to the s3 cache behavior that...
- if cache hit in s3
- and cache hit locally ala "tar://"
- then prefer to use the local tar cache hit and skip pulling from s3

I  thought to remove the call to check the s3 cache but thought that might be confusing. As-is this leaves S3 as the source of truth. If there is no s3 cache hit then this step will behave as it has before, where nothing will happen.

This is being tested here: https://github.com/fast-af/monorepo/pull/4122

See "Build Monorepo" step here: https://buildkite.com/fast-af/required-tests/builds/14681#d79a6c5d-3ebf-45fb-9763-a3c8feaaf8a9

<img width="912" alt="Screen Shot 2021-03-31 at 12 41 53 PM" src="https://user-images.githubusercontent.com/6539929/113201586-83a16a00-921e-11eb-9cdd-53443af54c62.png">
